### PR TITLE
Add basic auth module with role-based access

### DIFF
--- a/cmd/finanzas/main.go
+++ b/cmd/finanzas/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"finanzas-api/config"
+	"finanzas-api/internal/auth"
+	authRoutes "finanzas-api/internal/auth/routes"
 	"finanzas-api/internal/users"
-	"finanzas-api/internal/users/routes"
+	userRoutes "finanzas-api/internal/users/routes"
 	DataBase "finanzas-api/shared/db"
 	"fmt"
 	"log"
@@ -40,7 +42,10 @@ func main() {
 	}
 
 	userModule := users.NewUsersModule(db)
-	routes.SetupUserRoutes(r, userModule.Handler)
+	authModule := auth.NewAuthModule(db, config)
+
+	authRoutes.SetupAuthRoutes(r, authModule.Handler)
+	userRoutes.SetupUserRoutes(r, userModule.Handler, authModule.Middleware.Handler)
 
 	log.Println("🚀 Servidor iniciado en " + config.Server.Host + ":" + strconv.Itoa(config.Server.Port))
 	r.Run(config.Server.Host + ":" + strconv.Itoa(config.Server.Port))

--- a/internal/auth/auth.module.go
+++ b/internal/auth/auth.module.go
@@ -1,1 +1,26 @@
 package auth
+
+import (
+	"finanzas-api/config"
+	"finanzas-api/internal/auth/domain"
+	"finanzas-api/internal/auth/handler"
+	"finanzas-api/internal/auth/middleware"
+	"finanzas-api/internal/auth/usecase"
+	userRepo "finanzas-api/internal/users/repository"
+
+	"gorm.io/gorm"
+)
+
+type AuthModule struct {
+	Handler    *handler.AuthHandler
+	UseCase    domain.AuthUseCase
+	Middleware *middleware.Middleware
+}
+
+func NewAuthModule(db *gorm.DB, cfg *config.Config) *AuthModule {
+	repo := userRepo.NewUserPostgresRepository(db)
+	uc := usecase.NewAuthUseCase(repo, cfg.JWT)
+	h := handler.NewAuthHandler(uc)
+	mw := middleware.NewMiddleware(cfg.JWT.Secret)
+	return &AuthModule{Handler: h, UseCase: uc, Middleware: mw}
+}

--- a/internal/auth/domain/auth.go
+++ b/internal/auth/domain/auth.go
@@ -1,0 +1,6 @@
+package domain
+
+// AuthUseCase defines authentication methods
+type AuthUseCase interface {
+	Login(email, password string) (string, error)
+}

--- a/internal/auth/handler/auth.handler.go
+++ b/internal/auth/handler/auth.handler.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"net/http"
+
+	"finanzas-api/internal/auth/domain"
+	"github.com/gin-gonic/gin"
+)
+
+type AuthHandler struct {
+	useCase domain.AuthUseCase
+}
+
+func NewAuthHandler(uc domain.AuthUseCase) *AuthHandler {
+	return &AuthHandler{useCase: uc}
+}
+
+type LoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+type LoginResponse struct {
+	Token string `json:"token"`
+}
+
+func (h *AuthHandler) Login(c *gin.Context) {
+	var req LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	token, err := h.useCase.Login(req.Email, req.Password)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, LoginResponse{Token: token})
+}

--- a/internal/auth/middleware/auth.middleware.go
+++ b/internal/auth/middleware/auth.middleware.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"finanzas-api/shared/security"
+	"github.com/gin-gonic/gin"
+)
+
+type Middleware struct {
+	Secret string
+}
+
+func NewMiddleware(secret string) *Middleware {
+	return &Middleware{Secret: secret}
+}
+
+func (m *Middleware) Handler(roles ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			authHeader = strings.TrimPrefix(authHeader, "Bearer ")
+		}
+		claims, err := security.ParseToken(authHeader, m.Secret)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		if len(roles) > 0 {
+			allowed := false
+			for _, r := range roles {
+				if claims.Role == r {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+				return
+			}
+		}
+		c.Set("userID", claims.UserID)
+		c.Set("userRole", claims.Role)
+		c.Next()
+	}
+}

--- a/internal/auth/routes/auth.routes.go
+++ b/internal/auth/routes/auth.routes.go
@@ -1,0 +1,10 @@
+package routes
+
+import (
+	"finanzas-api/internal/auth/handler"
+	"github.com/gin-gonic/gin"
+)
+
+func SetupAuthRoutes(router *gin.Engine, h *handler.AuthHandler) {
+	router.POST("/api/v1/login", h.Login)
+}

--- a/internal/auth/usecase/auth.usecase.go
+++ b/internal/auth/usecase/auth.usecase.go
@@ -1,0 +1,32 @@
+package usecase
+
+import (
+	"errors"
+
+	"finanzas-api/config"
+	userDomain "finanzas-api/internal/users/domain"
+	"finanzas-api/shared/security"
+)
+
+type AuthUseCase struct {
+	userRepo  userDomain.UserRepository
+	jwtConfig config.JWTConfig
+}
+
+func NewAuthUseCase(repo userDomain.UserRepository, cfg config.JWTConfig) *AuthUseCase {
+	return &AuthUseCase{userRepo: repo, jwtConfig: cfg}
+}
+
+func (uc *AuthUseCase) Login(email, password string) (string, error) {
+	user, err := uc.userRepo.GetByEmail(email)
+	if err != nil {
+		return "", errors.New("invalid credentials")
+	}
+	if !security.CheckPasswordHash(password, user.Password) {
+		return "", errors.New("invalid credentials")
+	}
+	if !user.IsValidForAuth() {
+		return "", errors.New("user inactive")
+	}
+	return security.GenerateToken(user.ID, user.Role, uc.jwtConfig.Secret, uc.jwtConfig.Expires)
+}

--- a/internal/users/domain/user.go
+++ b/internal/users/domain/user.go
@@ -12,6 +12,7 @@ type User struct {
 	Password  string         `json:"-" gorm:"not null"` // El "-" oculta la contraseña en JSON
 	FirstName string         `json:"first_name" gorm:"not null"`
 	LastName  string         `json:"last_name" gorm:"not null"`
+	Role      string         `json:"role" gorm:"default:'user'"`
 	IsActive  bool           `json:"is_active" gorm:"default:true"`
 	CreatedAt time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`

--- a/internal/users/handler/user.handler.go
+++ b/internal/users/handler/user.handler.go
@@ -26,6 +26,7 @@ type CreateUserRequest struct {
 	FirstName string `json:"first_name" binding:"required"`
 	LastName  string `json:"last_name" binding:"required"`
 	Password  string `json:"password" binding:"required,min=6"`
+	Role      string `json:"role" binding:"omitempty,oneof=admin user"`
 }
 
 // UpdateUserRequest representa la estructura de la petición para actualizar usuario
@@ -34,6 +35,7 @@ type UpdateUserRequest struct {
 	FirstName string `json:"first_name" binding:"omitempty"`
 	LastName  string `json:"last_name" binding:"omitempty"`
 	IsActive  *bool  `json:"is_active" binding:"omitempty"`
+	Role      string `json:"role" binding:"omitempty,oneof=admin user"`
 }
 
 // UserResponse representa la respuesta de usuario (sin contraseña)
@@ -42,6 +44,7 @@ type UserResponse struct {
 	Email     string `json:"email"`
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
+	Role      string `json:"role"`
 	FullName  string `json:"full_name"`
 	IsActive  bool   `json:"is_active"`
 	CreatedAt string `json:"created_at"`
@@ -65,7 +68,12 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		FirstName: req.FirstName,
 		LastName:  req.LastName,
 		Password:  req.Password, // En un caso real, esto debería hashearse
+		Role:      req.Role,
 		IsActive:  true,
+	}
+
+	if user.Role == "" {
+		user.Role = "user"
 	}
 
 	if err := h.userUseCase.CreateUser(user); err != nil {
@@ -146,6 +154,9 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 	}
 	if req.IsActive != nil {
 		user.IsActive = *req.IsActive
+	}
+	if req.Role != "" {
+		user.Role = req.Role
 	}
 
 	if err := h.userUseCase.UpdateUser(user); err != nil {
@@ -231,6 +242,7 @@ func (h *UserHandler) toUserResponse(user *domain.User) UserResponse {
 		Email:     user.Email,
 		FirstName: user.FirstName,
 		LastName:  user.LastName,
+		Role:      user.Role,
 		FullName:  user.GetFullName(),
 		IsActive:  user.IsActive,
 		CreatedAt: user.CreatedAt.Format("2006-01-02T15:04:05Z"),

--- a/internal/users/routes/user.routes.go
+++ b/internal/users/routes/user.routes.go
@@ -7,24 +7,24 @@ import (
 )
 
 // SetupUserRoutes configura las rutas para el módulo de usuarios
-func SetupUserRoutes(router *gin.Engine, userHandler *handler.UserHandler) {
+func SetupUserRoutes(router *gin.Engine, userHandler *handler.UserHandler, authMiddleware func(...string) gin.HandlerFunc) {
 	// Grupo de rutas para usuarios
 	userRoutes := router.Group("/api/v1/users")
 	{
-		// POST /api/v1/users - Crear usuario
-		userRoutes.POST("", userHandler.CreateUser)
+		// POST /api/v1/users - Crear usuario (solo admin)
+		userRoutes.POST("", authMiddleware("admin"), userHandler.CreateUser)
 
-		// GET /api/v1/users - Listar usuarios
-		userRoutes.GET("", userHandler.ListUsers)
+		// GET /api/v1/users - Listar usuarios (solo admin)
+		userRoutes.GET("", authMiddleware("admin"), userHandler.ListUsers)
 
 		// GET /api/v1/users/:id - Obtener usuario por ID
-		userRoutes.GET("/:id", userHandler.GetUser)
+		userRoutes.GET("/:id", authMiddleware("admin", "user"), userHandler.GetUser)
 
 		// PUT /api/v1/users/:id - Actualizar usuario
-		userRoutes.PUT("/:id", userHandler.UpdateUser)
+		userRoutes.PUT("/:id", authMiddleware("admin", "user"), userHandler.UpdateUser)
 
-		// DELETE /api/v1/users/:id - Eliminar usuario
-		userRoutes.DELETE("/:id", userHandler.DeleteUser)
+		// DELETE /api/v1/users/:id - Eliminar usuario (solo admin)
+		userRoutes.DELETE("/:id", authMiddleware("admin"), userHandler.DeleteUser)
 	}
 }
 

--- a/shared/security/token.go
+++ b/shared/security/token.go
@@ -1,0 +1,62 @@
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+type TokenClaims struct {
+	UserID uint   `json:"user_id"`
+	Role   string `json:"role"`
+	Exp    int64  `json:"exp"`
+}
+
+func GenerateToken(userID uint, role string, secret string, duration time.Duration) (string, error) {
+	claims := TokenClaims{
+		UserID: userID,
+		Role:   role,
+		Exp:    time.Now().Add(duration).Unix(),
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	unsigned := header + "." + payload
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(unsigned))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return unsigned + "." + signature, nil
+}
+
+func ParseToken(tokenString, secret string) (*TokenClaims, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid token")
+	}
+	unsigned := parts[0] + "." + parts[1]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(unsigned))
+	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(parts[2])) {
+		return nil, errors.New("invalid signature")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	var claims TokenClaims
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, err
+	}
+	if time.Now().Unix() > claims.Exp {
+		return nil, errors.New("token expired")
+	}
+	return &claims, nil
+}


### PR DESCRIPTION
## Summary
- add role field to user domain and expose in API
- implement auth module with login handler and middleware
- generate tokens with lightweight HMAC-based implementation
- guard user routes depending on role
- wire auth and user modules in main

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684261bbcfc883298298596984140739